### PR TITLE
update for Sage9/Python3 compatibility

### DIFF
--- a/sage-impl/bls_sig_common.sage
+++ b/sage-impl/bls_sig_common.sage
@@ -43,7 +43,7 @@ def print_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, prin
     sig = sign_fn(x_prime, msg, ciphersuite)
 
     if is_genvec():
-        print hexlify(msg), hexlify(sk), hexlify(serialize(sig))
+        print(hexlify(msg), hexlify(sk), hexlify(serialize(sig)))
         return
 
     if sig_expect is not None:
@@ -53,15 +53,15 @@ def print_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, prin
             raise DeserError("deserializing sig_expect did not give sig")
 
     # output the test vector
-    print "================== begin test vector ===================="
+    print("================== begin test vector ====================")
 
-    print "g1 generator:"
+    print("g1 generator:")
     print_g1_hex(g1gen)
 
-    print "g2 generator:"
+    print("g2 generator:")
     print_g2_hex(g2gen)
 
-    print "group order: 0x%x" % q
+    print("group order: 0x%x" % q)
 
     sys.stdout.write("ciphersuite: ")
     print_value(ciphersuite, 13, True)
@@ -72,13 +72,13 @@ def print_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, prin
     sys.stdout.write("sk:          ")
     print_value(sk, 13, True)
 
-    print "public key:"
+    print("public key:")
     print_pk_fn(pk)
 
-    print "signature:"
+    print("signature:")
     print_sig_fn(sig)
 
-    print "==================  end test vector  ===================="
+    print("==================  end test vector  ====================")
 
 def print_pop_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, print_sig_fn, curve):
     if len(sig_in) > 2:
@@ -92,7 +92,7 @@ def print_pop_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, 
     sig = sign_fn(x_prime, pk, ciphersuite)
 
     if is_genvec():
-        print '00', hexlify(sk), hexlify(serialize(sig))
+        print('00', hexlify(sk), hexlify(serialize(sig)))
         return
 
     if sig_expect is not None:
@@ -102,15 +102,15 @@ def print_pop_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, 
             raise DeserError("deserializing sig_expect did not give sig")
 
     # output the test vector
-    print "================== begin test vector ===================="
+    print("================== begin test vector ====================")
 
-    print "g1 generator:"
+    print("g1 generator:")
     print_g1_hex(g1gen)
 
-    print "g2 generator:"
+    print("g2 generator:")
     print_g2_hex(g2gen)
 
-    print "group order: 0x%x" % q
+    print("group order: 0x%x" % q)
 
     sys.stdout.write("ciphersuite: ")
     print_value(ciphersuite, 13, True)
@@ -118,13 +118,13 @@ def print_pop_test_vector(sig_in, ciphersuite, sign_fn, keygen_fn, print_pk_fn, 
     sys.stdout.write("sk:          ")
     print_value(sk, 13, True)
 
-    print "public key:"
+    print("public key:")
     print_pk_fn(pk)
 
-    print "signature:"
+    print("signature:")
     print_sig_fn(sig)
 
-    print "==================  end test vector  ===================="
+    print("==================  end test vector  ====================")
 
 def print_hash_test_vector(hash_in, ciphersuite, hash_fn, print_pt_fn, curve):
     if len(hash_in) > 2:
@@ -136,7 +136,7 @@ def print_hash_test_vector(hash_in, ciphersuite, hash_fn, print_pt_fn, curve):
     P = hash_fn(msg, ciphersuite)
 
     if is_genvec():
-        print hexlify(msg), '00', hexlify(serialize(P))
+        print(hexlify(msg), '00', hexlify(serialize(P)))
         return
 
     if hash_expect is not None:
@@ -145,7 +145,7 @@ def print_hash_test_vector(hash_in, ciphersuite, hash_fn, print_pt_fn, curve):
         if deserialize(hash_expect, curve) != P:
             raise DeserError("deserializing hash_expect did not give P")
 
-    print "=============== begin hash test vector =================="
+    print("=============== begin hash test vector ==================")
 
     sys.stdout.write("ciphersuite: ")
     print_value(ciphersuite, 13, True)
@@ -153,7 +153,7 @@ def print_hash_test_vector(hash_in, ciphersuite, hash_fn, print_pt_fn, curve):
     sys.stdout.write("message:     ")
     print_value(msg, 13, True)
 
-    print "result:"
+    print("result:")
     print_pt_fn(P)
 
-    print "===============  end hash test vector  =================="
+    print("===============  end hash test vector  ==================")

--- a/sage-impl/g1_common.sage
+++ b/sage-impl/g1_common.sage
@@ -6,7 +6,7 @@
 import hashlib
 
 from hash_to_field import hash_to_base, hkdf_extract, hkdf_expand, OS2IP
-from util import print_iv, is_debug
+from util import as_bytes, print_iv, is_debug
 
 # BLS12-381 G1 curve
 ell_u = -0xd201000000010000
@@ -45,14 +45,14 @@ def Hp2(msg, ctr, dst=None):
     return hash_to_base(msg, ctr, dst, p, 2, 64, hashlib.sha256)
 
 def xprime_from_sk(msg):
-    prk = hkdf_extract("BLS-SIG-KEYGEN-SALT-", msg, hashlib.sha256)
+    prk = hkdf_extract(as_bytes("BLS-SIG-KEYGEN-SALT-"), as_bytes(msg), hashlib.sha256)
     okm = hkdf_expand(prk, None, 48, hashlib.sha256)
     return OS2IP(okm) % q
 
 # print out a point on g1
 def print_g1_hex(P, margin=8):
-    print " " * margin + " x = 0x%x" % int(P[0])
-    print " " * margin + " y = 0x%x" % int(P[1])
+    print(" " * margin + " x = 0x%x" % int(P[0]))
+    print(" " * margin + " y = 0x%x" % int(P[1]))
 
 # print an intermediate value comprising a point on g1
 def print_iv_g1(P, name, fn):

--- a/sage-impl/g2_common.sage
+++ b/sage-impl/g2_common.sage
@@ -45,8 +45,8 @@ def clear_h2(P):
 def print_F2_hex(vv, name, margin=8):
     vv = ZZR(vv)
     indent_str = " " * margin
-    print indent_str + name + "0 = 0x%x" % int(vv[0])
-    print indent_str + name + "1 = 0x%x" % int(vv[1])
+    print(indent_str + name + "0 = 0x%x" % int(vv[0]))
+    print(indent_str + name + "1 = 0x%x" % int(vv[1]))
 
 # print out a point on g2
 def print_g2_hex(P, margin=8):

--- a/sage-impl/hash_to_field.py
+++ b/sage-impl/hash_to_field.py
@@ -1,16 +1,24 @@
 #!/usr/bin/python2
 #
-# Python2/Sage implementation of hash-to-field as specified in
-#     https://github.com/pairingwg/bls_standard/blob/master/minutes/spec-v1.md
 
 import hashlib
 import hmac
 import struct
 import sys
-if sys.version_info[0] != 2:
-    raise RuntimeError("this code is geared toward Python2/Sage, not Python3")
-
-from util import print_iv # pylint: disable=wrong-import-position
+from util import as_bytes, print_iv
+if sys.version_info[0] == 3:
+    xrange = range
+    NULL_BYTE = b'\x00'
+    NULL_STRING = b''
+    H2C_STRING = b'H2C'
+    X0B_STRING = b'\x0b'
+    X0C_STRING = b'\x0c'
+else:
+    NULL_BYTE = '\x00'
+    NULL_STRING = ''
+    H2C_STRING = 'H2C'
+    X0B_STRING = '\x0b'
+    X0C_STRING = '\x0c'
 
 # defined in RFC 3447, section 4.1
 def I2OSP(val, length):
@@ -39,7 +47,7 @@ def OS2IP(octets, skip_assert=False):
 # per RFC5869
 def hkdf_extract(salt, ikm, hash_fn):
     if salt is None:
-        salt = '\x00' * hash_fn().digest_size
+        salt = NULL_BYTE * hash_fn().digest_size
     return hmac.HMAC(salt, ikm, hash_fn).digest()
 def hkdf_expand(prk, info, length, hash_fn):
     digest_size = hash_fn().digest_size
@@ -49,35 +57,35 @@ def hkdf_expand(prk, info, length, hash_fn):
     if nreps == 0 or nreps > 255:
         raise ValueError("length arg to hkdf_expand cannot be longer than 255 * Hashlen")
     if info is None:
-        info = ''
-    last = okm = ''
+        info = NULL_STRING
+    last = okm = NULL_STRING
     for rep in range(0, nreps):
         last = hmac.HMAC(prk, last + info + I2OSP(rep + 1, 1), hash_fn).digest()
         okm += last
     return okm[:length]
 
-# from draft-irtf-cfrg-hash-to-curve
+# from draft-irtf-cfrg-hash-to-curve-05
 def hash_to_base(msg, ctr, dst, modulus, degree, blen, hash_fn):
     print_iv(msg, "msg to hash", "hash_to_base")
 
-    msg_prime = hkdf_extract(dst, msg + '\x00', hash_fn)
+    msg_prime = hkdf_extract(as_bytes(dst), as_bytes(msg) + NULL_BYTE, hash_fn)
     print_iv(msg_prime, "m'", "hash_to_base")
 
     rets = [None] * degree
-    info = 'H2C' + I2OSP(ctr, 1)
+    info_pfx = H2C_STRING + I2OSP(ctr, 1)
     for i in range(0, degree):
-        t = hkdf_expand(msg_prime, info + I2OSP(i + 1, 1), blen, hash_fn)
+        info = info_pfx + I2OSP(i + 1, 1)
+        t = hkdf_expand(msg_prime, info, blen, hash_fn)
         print_iv(t, "t", "hash_to_base")
-
         rets[i] = OS2IP(t) % modulus
         print_iv(rets[i], "rets[%d]" % i, "hash_to_base")
 
     return rets
 
-def test():
+def test_hkdf():
     # test cases from RFC5869
     test_cases = [ ( hashlib.sha256
-                   , '\x0b' * 22
+                   , X0B_STRING * 22
                    , I2OSP(0x000102030405060708090a0b0c, 13)
                    , I2OSP(0xf0f1f2f3f4f5f6f7f8f9, 10)
                    , 42
@@ -93,15 +101,15 @@ def test():
                    , I2OSP(0xb11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87, 82)
                    ),
                    ( hashlib.sha256
-                   , '\x0b' * 22
-                   , ''
-                   , ''
+                   , X0B_STRING * 22
+                   , NULL_STRING
+                   , NULL_STRING
                    , 42
                    , I2OSP(0x19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04, 32)
                    , I2OSP(0x8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8, 42)
                    ),
                    ( hashlib.sha1
-                   , '\x0b' * 11
+                   , X0B_STRING * 11
                    , I2OSP(0x000102030405060708090a0b0c, 13)
                    , I2OSP(0xf0f1f2f3f4f5f6f7f8f9, 10)
                    , 42
@@ -117,17 +125,17 @@ def test():
                    , I2OSP(0x0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4, 82)
                    ),
                    ( hashlib.sha1
-                   , '\x0b' * 22
-                   , ''
-                   , ''
+                   , X0B_STRING * 22
+                   , NULL_STRING
+                   , NULL_STRING
                    , 42
                    , I2OSP(0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01, 20)
                    , I2OSP(0x0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918, 42)
                    ),
                    ( hashlib.sha1
-                   , '\x0c' * 22
+                   , X0C_STRING * 22
                    , None
-                   , ''
+                   , NULL_STRING
                    , 42
                    , I2OSP(0x2adccada18779e7c2077ad2eb19d3f3e731385dd, 20)
                    , I2OSP(0x2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48, 42)
@@ -140,4 +148,4 @@ def test():
         assert op == o, "okm mismatch"
 
 if __name__ == "__main__":
-    test()
+    test_hkdf()

--- a/sage-impl/serdesZ.sage
+++ b/sage-impl/serdesZ.sage
@@ -45,6 +45,8 @@
 
 import struct
 import sys
+if sys.version_info[0] == 3:
+    xrange = range
 
 try:
     from __sage__g1_common import Ell, F, ZZR, p, sgn0

--- a/sage-impl/util.py
+++ b/sage-impl/util.py
@@ -6,8 +6,10 @@ import binascii
 import getopt
 import struct
 import sys
-if sys.version_info[0] != 2:
-    raise RuntimeError("this code is geared toward Python2/Sage, not Python3")
+if sys.version_info[0] == 3:
+    as_bytes = lambda x: bytes(x, "utf-8") if isinstance(x, str) else x
+else:
+    as_bytes = lambda x: x
 
 DEBUG = False
 GENVEC = False
@@ -36,8 +38,8 @@ def print_iv(iv, name, fn, indent=8):
 def print_value(iv, indent=8, skip_first=False):
     max_line_length = 111
     if isinstance(iv, str):
-        cs = struct.unpack("=" + "B" * len(iv), iv)
-    elif isinstance(iv, list):
+        cs = struct.unpack("=" + "B" * len(iv), as_bytes(iv))
+    elif isinstance(iv, (list, bytes)):
         cs = iv
     else:
         cs = [iv]
@@ -47,6 +49,8 @@ def print_value(iv, indent=8, skip_first=False):
     if not skip_first:
         sys.stdout.write(indent_string)
     for c in cs:
+        if isinstance(c, bytes):
+            c = ord(c)
         out_str = "0x%02x" % c
         if line_length + len(out_str) > max_line_length:
             sys.stdout.write("\n%s" % indent_string)
@@ -66,7 +70,7 @@ def get_cmdline_options():
         (opts, args) = getopt.gnu_getopt(sys.argv[1:], "k:dgT:BAP")
 
     except getopt.GetoptError as err:
-        print "Usage: %s [-B | -A | -P] [-g] [-d] [-k key] [-T test_file] [msg ...]" % sys.argv[0]
+        print("Usage: %s [-B | -A | -P] [-g] [-d] [-k key] [-T test_file] [msg ...]" % sys.argv[0])
         sys.exit(str(err))
 
     for (opt, arg) in opts:


### PR DESCRIPTION
Sage9 uses Python3 instead of Python2. These changes make the sage impl compatible with both Sage9/Py3 and Sage8/Py2.

Tested with Sage9 (archlinux) and Sage8.1 (ubuntu)